### PR TITLE
Fix webhook secret comparison

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -125,7 +125,7 @@ func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Req
 
 	configuration := p.getConfiguration()
 	for _, alertConfig := range configuration.AlertConfigs {
-		if subtle.ConstantTimeCompare([]byte(token), []byte(alertConfig.Token)) == 0 {
+		if subtle.ConstantTimeCompare([]byte(token), []byte(alertConfig.Token)) == 1 {
 			switch r.URL.Path {
 			case "/api/webhook":
 				p.handleWebhook(w, r, alertConfig)


### PR DESCRIPTION
`subtle.ConstantTimeCompare` returns `1` if the slices have equal content. The check for `0` is wrong.

Fixes https://github.com/cpanato/mattermost-plugin-alertmanager/issues/117