### PR TITLE
Add Basic Auth support

### DIFF
--- a/server/actions.go
+++ b/server/actions.go
@@ -28,7 +28,7 @@ func (p *Plugin) handleExpireAction(w http.ResponseWriter, r *http.Request, aler
 
 	silenceDeletedMsg := fmt.Sprintf("Silence %s expired.", action.Context.SilenceID)
 
-	err := alertmanager.ExpireSilence(action.Context.SilenceID, alertConfig.AlertManagerURL)
+	err := alertmanager.ExpireSilence(action.Context.SilenceID, alertConfig.AlertManagerURL, alertConfig.User, alertConfig.Password)
 	if err != nil {
 		msg := fmt.Sprintf("failed to expire the silence: %v", err)
 		encodeEphermalMessage(w, msg)

--- a/server/alertmanager/alerts.go
+++ b/server/alertmanager/alerts.go
@@ -8,8 +8,8 @@ import (
 )
 
 // ListAlerts returns a slice of Alert and an error.
-func ListAlerts(alertmanagerURL string) ([]*types.Alert, error) {
-	resp, err := httpRetry(http.MethodGet, alertmanagerURL+"/api/v2/alerts")
+func ListAlerts(alertmanagerURL string, username string, password string) ([]*types.Alert, error) {
+	resp, err := httpRetry(http.MethodGet, alertmanagerURL+"/api/v2/alerts", username, password)
 	if err != nil {
 		return nil, err
 	}

--- a/server/alertmanager/retry.go
+++ b/server/alertmanager/retry.go
@@ -17,7 +17,7 @@ func httpBackoff() *backoff.ExponentialBackOff {
 	return b
 }
 
-func httpRetry(method string, url string) (*http.Response, error) {
+func httpRetry(method string, url string, username string, password string) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 
@@ -28,6 +28,10 @@ func httpRetry(method string, url string) (*http.Response, error) {
 		req, errReq := http.NewRequest(method, url, nil)
 		if errReq != nil {
 			return errReq
+		}
+
+		if username != "" && password != "" {
+			req.SetBasicAuth(username, password)
 		}
 
 		req = req.WithContext(ctx)

--- a/server/alertmanager/silences.go
+++ b/server/alertmanager/silences.go
@@ -13,8 +13,8 @@ import (
 )
 
 // ListSilences returns a slice of Silence and an error.
-func ListSilences(alertmanagerURL string) ([]types.Silence, error) {
-	resp, err := httpRetry(http.MethodGet, alertmanagerURL+"/api/v2/silences")
+func ListSilences(alertmanagerURL string, username string, password string) ([]types.Silence, error) {
+	resp, err := httpRetry(http.MethodGet, alertmanagerURL+"/api/v2/silences", username, password)
 	if err != nil {
 		return nil, err
 	}
@@ -35,13 +35,13 @@ func ListSilences(alertmanagerURL string) ([]types.Silence, error) {
 }
 
 // DeleteSilence delete a silence by ID.
-func ExpireSilence(silenceID, alertmanagerURL string) error {
+func ExpireSilence(silenceID, alertmanagerURL string, username string, password string) error {
 	if silenceID == "" {
 		return fmt.Errorf("silence ID cannot be empty")
 	}
 
 	expireSilence := fmt.Sprintf("%s/api/v2/silence/%s", alertmanagerURL, silenceID)
-	resp, err := httpRetry(http.MethodDelete, expireSilence)
+	resp, err := httpRetry(http.MethodDelete, expireSilence, username, password)
 	if err != nil {
 		return err
 	}

--- a/server/alertmanager/status.go
+++ b/server/alertmanager/status.go
@@ -20,10 +20,10 @@ type StatusResponse struct {
 }
 
 // Status returns a StatusResponse or an error.
-func Status(alertmanagerURL string) (StatusResponse, error) {
+func Status(alertmanagerURL string, username string, password string) (StatusResponse, error) {
 	var statusResponse StatusResponse
 
-	resp, err := httpRetry(http.MethodGet, alertmanagerURL+"/api/v2/status")
+	resp, err := httpRetry(http.MethodGet, alertmanagerURL+"/api/v2/status", username, password)
 	if err != nil {
 		return statusResponse, err
 	}

--- a/server/commands.go
+++ b/server/commands.go
@@ -139,7 +139,7 @@ func (p *Plugin) handleAlert(args *model.CommandArgs) (string, error) {
 	var errors []string
 
 	for _, alertConfig := range configuration.AlertConfigs {
-		alerts, err := alertmanager.ListAlerts(alertConfig.AlertManagerURL)
+		alerts, err := alertmanager.ListAlerts(alertConfig.AlertManagerURL, alertConfig.User, alertConfig.Password)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("AlertManagerURL %q: failed to list alerts... %v", alertConfig.AlertManagerURL, err))
 			continue
@@ -200,7 +200,7 @@ func (p *Plugin) handleStatus(args *model.CommandArgs) (string, error) {
 
 	var errors []string
 	for _, alertConfig := range configuration.AlertConfigs {
-		status, err := alertmanager.Status(alertConfig.AlertManagerURL)
+		status, err := alertmanager.Status(alertConfig.AlertManagerURL, alertConfig.User, alertConfig.Password)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("AlertManagerURL %q: failed to get status... %v", alertConfig.AlertManagerURL, err))
 			continue
@@ -249,7 +249,7 @@ func (p *Plugin) handleListSilences(args *model.CommandArgs) (string, error) {
 	siteURLPort := *config.ServiceSettings.ListenAddress
 
 	for _, alertConfig := range configuration.AlertConfigs {
-		silences, err := alertmanager.ListSilences(alertConfig.AlertManagerURL)
+		silences, err := alertmanager.ListSilences(alertConfig.AlertManagerURL, alertConfig.User, alertConfig.Password)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("AlertManagerURL %q: failed to get silences... %v", alertConfig.AlertManagerURL, err))
 			continue
@@ -314,7 +314,7 @@ func (p *Plugin) handleExpireSilence(args *model.CommandArgs) (string, error) {
 	configuration := p.getConfiguration()
 
 	if config, ok := configuration.AlertConfigs[parameters[0]]; ok {
-		err := alertmanager.ExpireSilence(parameters[1], config.AlertManagerURL)
+		err := alertmanager.ExpireSilence(parameters[1], config.AlertManagerURL, config.User, config.Password)
 		if err != nil {
 			return "", fmt.Errorf("failed to expire the silence: %w", err)
 		}

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -28,6 +28,8 @@ type alertConfig struct {
 	Channel         string
 	Team            string
 	AlertManagerURL string
+	User            string
+	Password        string
 }
 
 func (ac *alertConfig) IsValid() error {

--- a/webapp/src/components/admin_settings/AMAttribute.jsx
+++ b/webapp/src/components/admin_settings/AMAttribute.jsx
@@ -90,7 +90,7 @@ const AMAttribute = (props) => {
         props.onChange({id: props.id, attributes:newSettings});
     }
 
-    const generateSimpleStringInputSetting = ( title, settingName, onChangeFunction, helpTextJSX) => {
+    const generateSimpleStringInputSetting = ( title, settingName, onChangeFunction, helpTextJSX, isPassword = false) => {
         return (
             <div className="form-group" >
             <label className="control-label col-sm-4">
@@ -100,9 +100,10 @@ const AMAttribute = (props) => {
                 <input
                     id={`PluginSettings.Plugins.alertmanager.${settingName + "." + settings.id}`}
                     className="form-control"
-                    type="input"
+                    type={isPassword ? "password" : "text"}
                     onChange={onChangeFunction}
                     value={settings[settingName]}
+                    autoComplete={isPassword ? "new-password" : "off"}
                 />
                 <div className="help-text">
                     {helpTextJSX}
@@ -157,7 +158,7 @@ const AMAttribute = (props) => {
                         "Team Name:",
                         "team",
                         handleTeamNameInput,
-                        (<span>{"Team you want to send messages to. Use the team name such as \'my-team\', instead of the display name."}</span>)
+                        (<span>{"Team you want to send messages to. Use the team name such as \\'my-team\\', instead of the display name."}</span>)
                         )
                     }
 
@@ -182,7 +183,7 @@ const AMAttribute = (props) => {
                         "AlertManager URL:",
                         "alertmanagerurl",
                         handleURLInput,
-                        (<span>{"The URL of your AlertManager instance, e.g. \'"}<a href="http://alertmanager.example.com/" rel="noopener noreferrer" target="_blank">{"http://alertmanager.example.com/"}</a>{"\'"}</span>)
+                        (<span>{"The URL of your AlertManager instance, e.g. \\'"}<a href="http://alertmanager.example.com/" rel="noopener noreferrer" target="_blank">{"http://alertmanager.example.com/"}</a>{"\\'"}</span>)
                         )
                     }
 
@@ -208,7 +209,8 @@ const AMAttribute = (props) => {
                             setSettings(newSettings);
                             props.onChange({id: props.id, attributes: newSettings});
                         },
-                        (<span>{"Optional: Password for basic auth authentication"}</span>)
+                        (<span>{"Optional: Password for basic auth authentication"}</span>),
+                        true
                         )
                     }
                 </div>

--- a/webapp/src/components/admin_settings/AMAttribute.jsx
+++ b/webapp/src/components/admin_settings/AMAttribute.jsx
@@ -7,13 +7,15 @@ const AMAttribute = (props) => {
         channel: "",
         team: "",
         token: "",
-
+        user: "",
+        password: "",
     } : {
         alertmanagerurl: props.attributes.alertmanagerurl? props.attributes.alertmanagerurl: "",
         channel: props.attributes.channel? props.attributes.channel : "",
         team: props.attributes.team ? props.attributes.team: "",
         token: props.attributes.token? props.attributes.token: "",
-
+        user: props.attributes.user ? props.attributes.user: "",
+        password: props.attributes.password ? props.attributes.password: "",
     };
 
     const initErrors = {
@@ -181,6 +183,32 @@ const AMAttribute = (props) => {
                         "alertmanagerurl",
                         handleURLInput,
                         (<span>{"The URL of your AlertManager instance, e.g. \'"}<a href="http://alertmanager.example.com/" rel="noopener noreferrer" target="_blank">{"http://alertmanager.example.com/"}</a>{"\'"}</span>)
+                        )
+                    }
+
+                    { generateSimpleStringInputSetting(
+                        "User:",
+                        "user",
+                        (e) => {
+                            let newSettings = {...settings};
+                            newSettings = {...newSettings, user: e.target.value};
+                            setSettings(newSettings);
+                            props.onChange({id: props.id, attributes: newSettings});
+                        },
+                        (<span>{"Optional: Username for basic auth authentication"}</span>)
+                        )
+                    }
+
+                    { generateSimpleStringInputSetting(
+                        "Password:",
+                        "password",
+                        (e) => {
+                            let newSettings = {...settings};
+                            newSettings = {...newSettings, password: e.target.value};
+                            setSettings(newSettings);
+                            props.onChange({id: props.id, attributes: newSettings});
+                        },
+                        (<span>{"Optional: Password for basic auth authentication"}</span>)
                         )
                     }
                 </div>

--- a/webapp/src/components/admin_settings/CustomAttributeSettings.jsx
+++ b/webapp/src/components/admin_settings/CustomAttributeSettings.jsx
@@ -30,7 +30,9 @@ const CustomAttributesSettings = (props) => {
                 alertmanagerurl: '',
                 channel: '',
                 team: '',
-                token: ''
+                token: '',
+                user: '',
+                password: ''
             }
         };
 
@@ -96,7 +98,9 @@ const CustomAttributesSettings = (props) => {
                         team: value.team,
                         channel: value.channel,
                         token: value.token,
-                        alertmanagerurl: value.alertmanagerurl
+                        alertmanagerurl: value.alertmanagerurl,
+                        user: value.user,
+                        password: value.password
                     }}
                 />
             );


### PR DESCRIPTION
This PR adds Basic Auth support for Alertmanager HTTP requests, fixing issue #7.

## Changes

### Backend (Server)
- Added `User` and `Password` fields to `alertConfig` struct in `configuration.go`
- Modified HTTP request functions in `alertmanager/` package to include Basic Auth:
  - `retry.go`: Added auth parameters to `httpRetry()` function
  - `alerts.go`: Updated `ListAlerts()` with auth support
  - `silences.go`: Updated silence management functions
  - `status.go`: Updated status query functions
- Updated command handlers in `commands.go` to pass auth credentials
- Updated action handlers in `actions.go` to pass auth credentials

### Frontend (Webapp)
- Added User and Password input fields in `AMAttribute.jsx`
- Added configuration handling in `CustomAttributeSettings.jsx`
- Password field uses `type="password"` for security (hidden input)
- Added `autoComplete="new-password"` to prevent browser auto-fill

## Files Modified

- `server/configuration.go` - Added User/Password config fields
- `server/alertmanager/retry.go` - Core HTTP auth logic
- `server/alertmanager/alerts.go` - Alerts API with auth
- `server/alertmanager/silences.go` - Silences API with auth
- `server/alertmanager/status.go` - Status API with auth
- `server/commands.go` - Command handlers
- `server/actions.go` - Action handlers
- `webapp/src/components/admin_settings/AMAttribute.jsx` - UI fields
- `webapp/src/components/admin_settings/CustomAttributeSettings.jsx` - Settings handling

Fixes #7